### PR TITLE
Fix pipeline directories and add rename map tests

### DIFF
--- a/Dumby/Bulked_AI/README.md
+++ b/Dumby/Bulked_AI/README.md
@@ -6,7 +6,7 @@ Structure
 - Dumby/Bulked_AI: all Python sources
 - Dumby/Boxxed_Data: all outputs (created as needed)
   - 01_Batches: filelist_*.txt, metadata_batch_*.json (ExifTool)
-  - 02_NDJSON: structured_metadata*.02_NDJSON
+  - 02_NDJSON: structured_metadata*.ndjson
   - 03_PerFile_JSON: per-image JSON entries (optional)
   - 04_CSV: exported tables
   - 05_RenameMap: rename maps (02_NDJSON/04_CSV)
@@ -21,6 +21,6 @@ Quick Start (Interactive)
 Notes
 - ExifTool is auto-detected/installed when needed (no admin required).
 - Defaults write under Dumby\Boxxed_Data with per-type subfolders.
-- Persistent 00_Rules are stored at Dumby\Boxxed_Data\00_Rules\export_00_Rules.json.
+- Persistent 00_Rules are stored at Dumby\Boxxed_Data\00_Rules\export_rules.json.
 
 

--- a/Dumby/Bulked_AI/main.py
+++ b/Dumby/Bulked_AI/main.py
@@ -46,11 +46,15 @@ def run_pipeline_interactive() -> None:
     # Root for all outputs
     work_dir = Path(ui.strip_quotes(ui.prompt_input("Output root directory (Boxxed_Data)", str(getattr(pipeline, "DEFAULT_BOX_DIR", Path.cwd() / "Boxxed_Data")))))
     work_dir.mkdir(parents=True, exist_ok=True)
-    batches_dir = work_dir / "Batches"
-    ndjson_dir = work_dir / "NDJSON"
-    perfile_dir = work_dir / "PerFile_JSON"
+    batches_dir = work_dir / "01_Batches"
+    ndjson_dir = work_dir / "02_NDJSON"
+    perfile_dir = work_dir / "03_PerFile_JSON"
+    csv_dir = work_dir / "04_CSV"
+    rename_dir = work_dir / "05_RenameMap"
     batches_dir.mkdir(parents=True, exist_ok=True)
     ndjson_dir.mkdir(parents=True, exist_ok=True)
+    csv_dir.mkdir(parents=True, exist_ok=True)
+    rename_dir.mkdir(parents=True, exist_ok=True)
 
     # Batch size selection
     bs_opts = [100, 500, 1000, 1500, 2000, 3000, 4000, 5000]

--- a/Dumby/Bulked_AI/scripts/pipeline.py
+++ b/Dumby/Bulked_AI/scripts/pipeline.py
@@ -29,11 +29,11 @@ DEFAULT_PARSE_WORKERS = getattr(aimeta, "DEFAULT_PARSE_WORKERS", 4)
 # Dumby/
 #   Run_AI_Toolkit.bat
 #   Boxxed_Data/
-#     Batches/            (filelist_*.txt, metadata_batch_*.json)
-#     NDJSON/             (structured_metadata*.ndjson)
-#     PerFile_JSON/       (*.json per image if enabled)
-#     CSV/                (exports)
-#     RenameMap/          (map files)
+#     01_Batches/         (filelist_*.txt, metadata_batch_*.json)
+#     02_NDJSON/          (structured_metadata*.ndjson)
+#     03_PerFile_JSON/    (*.json per image if enabled)
+#     04_CSV/             (exports)
+#     05_RenameMap/       (map files)
 _DUMBY_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_BOX_DIR = _DUMBY_ROOT / "Boxxed_Data"
 DEFAULT_BATCHES_DIR = DEFAULT_BOX_DIR / "01_Batches"

--- a/tests/test_meta_export.py
+++ b/tests/test_meta_export.py
@@ -1,0 +1,52 @@
+import csv
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1] / "Dumby" / "Bulked_AI"
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from scripts.meta_export import (  # noqa: E402
+    export_ndjson_rename_map,
+    sanitize_filename_component,
+)
+
+
+def test_sanitize_filename_component_normalizes_invalid_characters():
+    dirty = '  Fancy<>:"Model*Name??  '
+    assert sanitize_filename_component(dirty) == "Fancy Model Name"
+
+
+def test_export_ndjson_rename_map_sanitizes_model_tags(tmp_path):
+    ndjson_path = tmp_path / "structured_metadata.ndjson"
+    entries = [
+        {
+            "SourceFile": "C:/images/fancy_one.png",
+            "AI_Metadata": {"Model": 'Fancy<>:"Model*Name??  '},
+        },
+        {
+            "SourceFile": "C:/images/fancy_two.png",
+            "AI_Metadata": {"Model": 'Fancy<>:"Model*Name??  '},
+        },
+    ]
+    with open(ndjson_path, "w", encoding="utf-8") as handle:
+        for entry in entries:
+            handle.write(json.dumps(entry))
+            handle.write("\n")
+
+    csv_path = tmp_path / "rename_map.csv"
+    export_ndjson_rename_map(ndjson_path, csv_path, sanitize=True, fmt="csv")
+    with open(csv_path, newline="", encoding="utf-8") as handle:
+        rows = list(csv.reader(handle))
+    assert rows[0] == ["ImageName", "ModelTag"]
+    assert rows[1][1] == "Fancy Model Name 1"
+    assert rows[2][1] == "Fancy Model Name 2"
+
+    ndjson_map = tmp_path / "rename_map.ndjson"
+    export_ndjson_rename_map(ndjson_path, ndjson_map, sanitize=True, fmt="ndjson")
+    with open(ndjson_map, "r", encoding="utf-8") as handle:
+        lines = [json.loads(line) for line in handle if line.strip()]
+
+    assert lines[0]["ModelTag"] == "Fancy Model Name 1"
+    assert lines[1]["ModelTag"] == "Fancy Model Name 2"


### PR DESCRIPTION
## Summary
- update the interactive pipeline to create the numbered Boxxed_Data subfolders and ensure export directories exist
- correct the Boxxed_Data structure documentation and default rules filename in the README and pipeline module comment
- add regression tests covering rename map sanitization and invalid character handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd5e45a3188321b0c93c28abcf56d7